### PR TITLE
Use http:// instead of git:// for cryptomilk

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ list(APPEND CMOCKA_ARGS "-DWITH_STATIC_LIB=ON;-DCMAKE_C_COMPILER=${CMAKE_C_COMPI
 include(ExternalProject)
 ExternalProject_Add(
   cmocka_cloned
-  GIT_REPOSITORY    git://git.cryptomilk.org/projects/cmocka.git
+  GIT_REPOSITORY    https://git.cryptomilk.org/projects/cmocka.git
   GIT_TAG           cmocka-1.1.0
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/cmocka-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/cmocka-build"

--- a/utils/zfp.c
+++ b/utils/zfp.c
@@ -317,22 +317,40 @@ int main(int argc, char* argv[])
     return EXIT_FAILURE;
   }
 
-  /* make sure we know floating-point type */
-  if ((inpath || !header) && !typesize) {
-    fprintf(stderr, "must specify scalar type via -f, -d, or -t or header via -h\n");
-    return EXIT_FAILURE;
+  /* make sure we (will) know scalar type */
+  if (!typesize) {
+    if (inpath) {
+      fprintf(stderr, "must specify scalar type via -f, -d, or -t to compress\n");
+      return EXIT_FAILURE;
+    }
+    else if (!header) {
+      fprintf(stderr, "must specify scalar type via -f, -d, or -t or header via -h to decompress\n");
+      return EXIT_FAILURE;
+    }
   }
 
-  /* make sure we know array dimensions */
-  if ((inpath || !header) && !dims) {
-    fprintf(stderr, "must specify array dimensions via -1, -2, or -3 or header via -h\n");
-    return EXIT_FAILURE;
+  /* make sure we (will) know array dimensions */
+  if (!dims) {
+    if (inpath) {
+      fprintf(stderr, "must specify array dimensions via -1, -2, -3, or -4 to compress\n");
+      return EXIT_FAILURE;
+    }
+    else if (!header) {
+      fprintf(stderr, "must specify array dimensions via -1, -2, -3, or -4 or header via -h to decompress\n");
+      return EXIT_FAILURE;
+    }
   }
 
-  /* make sure we know (de)compression mode and parameters */
-  if ((inpath || !header) && !mode) {
-    fprintf(stderr, "must specify compression parameters via -a, -c, -p, or -r or header via -h\n");
-    return EXIT_FAILURE;
+  /* make sure we (will) know (de)compression mode and parameters */
+  if (!mode) {
+    if (inpath) {
+      fprintf(stderr, "must specify compression parameters via -a, -c, -p, or -r to compress\n");
+      return EXIT_FAILURE;
+    }
+    else if (!header) {
+      fprintf(stderr, "must specify compression parameters via -a, -c, -p, or -r or header via -h to decompress\n");
+      return EXIT_FAILURE;
+    }
   }
 
   /* make sure we have input file for stats */


### PR DESCRIPTION
In many companies, the git:// protocol is blocked by corporate firewall. To circumvent that, use http:// instead of git://